### PR TITLE
ADF-75: Fix crash on template delete

### DIFF
--- a/draft-frontend/src/editor/templates.tsx
+++ b/draft-frontend/src/editor/templates.tsx
@@ -52,7 +52,7 @@ export class TemplatesTab implements Tab<EditorProps> {
     templateCtx: TemplateContext|undefined = undefined;
 
     setSelection(selection: string|undefined) {
-        if(this.templateCtx!.selectedTemplate !== selection) {
+        if(this.templateCtx!.selectedTemplate !== selection && this.templateCtx!.selectedTemplate !== undefined) {
             this.templateCtx!.tabCtx.currentTab().onClose();
         }
         this.templateCtx!.setSelection(selection);


### PR DESCRIPTION
Crash was caused by trying to close an editor twice. This change makes it so that setSelection does not close the open editor if the selected template is undefined.